### PR TITLE
Handling cyclic directory structures

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var Promise     = require( 'es6-promise' ).Promise;
  */
 function readDirectory( projectPath, credits, seen ) {
   credits = credits || [];
-  seen = seen || [];
+  seen    = seen || [];
 
   if ( seen[ projectPath ] ) {
     return credits;

--- a/index.js
+++ b/index.js
@@ -18,8 +18,15 @@ var Promise     = require( 'es6-promise' ).Promise;
  *
  * @tested
  */
-function readDirectory( projectPath, credits ) {
+function readDirectory( projectPath, credits, seen ) {
   credits = credits || [];
+  seen = seen || [];
+
+  if ( seen[ projectPath ] ) {
+    return credits;
+  }
+
+  seen[ projectPath ] = true;
 
   var depPath = path.join( projectPath, 'node_modules' );
 
@@ -47,7 +54,7 @@ function readDirectory( projectPath, credits ) {
         } );
       }
 
-      readDirectory( path.join( depPath, name ), credits );
+      readDirectory( fs.realpathSync( path.join( depPath, name ) ), credits, seen );
     }
   } );
 

--- a/index.spec.js
+++ b/index.spec.js
@@ -67,6 +67,18 @@ test( 'credits - folder exists', t => {
     );
     fs.symlinkSync( `${path}/linked`, `${path}/node_modules/linked` );
 
+
+    fs.mkdirSync( `${path}/node_modules/cycle` );
+    fs.writeFileSync(
+      `${path}/node_modules/cycle/package.json`,
+      JSON.stringify( { author : 'Bob Loblaw' } ),
+      'utf8'
+    );
+
+    fs.mkdirSync( `${path}/node_modules/cycle/node_modules` );
+    fs.symlinkSync( `${path}/node_modules/cycle`, `${path}/node_modules/cycle/node_modules/cycle` );
+
+
     credits( path )
       .then( credits => {
         t.same( credits[ 0 ].name, 'Alice Bobson' );
@@ -75,14 +87,14 @@ test( 'credits - folder exists', t => {
         t.same( credits[ 1 ].name, 'Bob Calsow' );
         t.same( credits[ 1 ].packages, [ 'boing', 'foo' ] );
 
-        t.same( credits[ 2 ].name, 'Randy Ran' );
-        t.same( credits[ 2 ].packages, [ 'baz' ] );
+        t.same( credits[ 2 ].name, 'Bob Loblaw' );
+        t.same( credits[ 2 ].packages, [ 'cycle', 'linked' ] );
 
-        t.same( credits[ 3 ].name, 'Bobby Bob' );
+        t.same( credits[ 3 ].name, 'Randy Ran' );
         t.same( credits[ 3 ].packages, [ 'baz' ] );
 
-        t.same( credits[ 4 ].name, 'Bob Loblaw' );
-        t.same( credits[ 4 ].packages, [ 'linked' ] );
+        t.same( credits[ 4 ].name, 'Bobby Bob' );
+        t.same( credits[ 4 ].packages, [ 'baz' ] );
 
         cleanUpCb();
 

--- a/index.spec.js
+++ b/index.spec.js
@@ -22,6 +22,7 @@ test( 'credits - folder exists', t => {
       'utf8'
     );
 
+
     fs.mkdirSync( `${path}/node_modules/bar/node_modules` );
     fs.mkdirSync( `${path}/node_modules/bar/node_modules/boom` );
 
@@ -56,6 +57,16 @@ test( 'credits - folder exists', t => {
       'utf8'
     );
 
+
+
+    fs.mkdirSync( `${path}/linked/` );
+    fs.writeFileSync(
+      `${path}/linked/package.json`,
+      JSON.stringify( { author : 'Bob Loblaw' } ),
+      'utf8'
+    );
+    fs.symlinkSync( `${path}/linked`, `${path}/node_modules/linked` );
+
     credits( path )
       .then( credits => {
         t.same( credits[ 0 ].name, 'Alice Bobson' );
@@ -69,6 +80,9 @@ test( 'credits - folder exists', t => {
 
         t.same( credits[ 3 ].name, 'Bobby Bob' );
         t.same( credits[ 3 ].packages, [ 'baz' ] );
+
+        t.same( credits[ 4 ].name, 'Bob Loblaw' );
+        t.same( credits[ 4 ].packages, [ 'linked' ] );
 
         cleanUpCb();
 


### PR DESCRIPTION
While I was developing I had a mangled mess of npm linked packages, and when I ran the credits-cli tool, it would just run, and then display nothing.

I traced it down to a symlink cycle.

I've added checks to ensure that symlinks are handled properly.
