### PR TITLE
Leverage all-stars for author de-dupe and additional usernames

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "tmp": "0.0.28"
   },
   "dependencies": {
+    "all-stars": "^0.1.0",
     "es6-promise": "^3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "tmp": "0.0.28"
   },
   "dependencies": {
-    "all-stars": "^1.0.0",
+    "all-stars": "^1.1.0",
     "es6-promise": "^3.0.2",
     "object-assign": "^4.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "tmp": "0.0.28"
   },
   "dependencies": {
-    "all-stars": "^0.1.0",
-    "es6-promise": "^3.0.2"
+    "all-stars": "^1.0.0",
+    "es6-promise": "^3.0.2",
+    "object-assign": "^4.0.1"
   }
 }

--- a/util/package.js
+++ b/util/package.js
@@ -1,5 +1,32 @@
 'use strict';
 
+var allStars = require( 'all-stars' );
+
+/**
+ * Check all-stars db for given person and normalize person data if found.
+ *
+ * @param  {Object|false} person object representing author or maintainer
+ *
+ * @return {Object|false}        same object given, possibly modified or augmented
+ */
+function getAllStar( person ) {
+  if ( !person ) return person;
+
+  var allStar = allStars( person );
+  if ( allStar ) {
+    // normalize name and email
+    var name = allStar.name();
+    var email = allStar.email();
+    if ( name ) person.name = name;
+    if ( email ) person.email = email;
+    // add values only defined in all-stars
+    person.npm = allStar.npmUser();
+    person.github = allStar.githubUser();
+    person.twitter = allStar.twitter();
+  }
+  return person;
+}
+
 /**
  * Parse npm string shorthand into object representation
  *
@@ -10,11 +37,11 @@
 function getPersonObject( personString ) {
   var regex = personString.match( /^(.*?)\s?(<(.*)>)?\s?(\((.*)\))?\s?$/ );
 
-  return {
+  return getAllStar( {
     name  : regex[ 1 ],
     email : regex[ 3 ],
     url   : regex[ 5 ]
-  };
+  } );
 }
 
 
@@ -32,9 +59,9 @@ function getAuthor( packageJson ) {
     return getPersonObject( packageJson.author );
   }
 
-  return packageJson.author ?
+  return getAllStar( packageJson.author ?
           packageJson.author :
-          false;
+          false );
 }
 
 
@@ -54,7 +81,7 @@ function getMaintainers( packageJson ) {
         return getPersonObject( maintainer );
       }
 
-      return maintainer;
+      return getAllStar( maintainer );
     } );
   }
 

--- a/util/package.js
+++ b/util/package.js
@@ -1,30 +1,18 @@
 'use strict';
 
 var allStars = require( 'all-stars' );
+var objectAssign = require( 'object-assign' );
 
 /**
- * Check all-stars db for given person and normalize person data if found.
+ * Check all-stars db for given person and assign to person if found.
  *
- * @param  {Object|false} person object representing author or maintainer
+ * @param  {Object} person object representing author or maintainer
  *
- * @return {Object|false}        same object given, possibly modified or augmented
+ * @return {Object}        same object given, possibly modified or augmented
  */
 function getAllStar( person ) {
-  if ( !person ) return person;
-
-  var allStar = allStars( person );
-  if ( allStar ) {
-    // normalize name and email
-    var name = allStar.name();
-    var email = allStar.email();
-    if ( name ) person.name = name;
-    if ( email ) person.email = email;
-    // add values only defined in all-stars
-    person.npm = allStar.npmUser();
-    person.github = allStar.githubUser();
-    person.twitter = allStar.twitter();
-  }
-  return person;
+  // override properties from all-stars if available
+  return objectAssign( person, allStars( person ) );
 }
 
 /**
@@ -59,9 +47,9 @@ function getAuthor( packageJson ) {
     return getPersonObject( packageJson.author );
   }
 
-  return getAllStar( packageJson.author ?
-          packageJson.author :
-          false );
+  return packageJson.author ?
+          getAllStar( packageJson.author ) :
+          false;
 }
 
 

--- a/util/package.js
+++ b/util/package.js
@@ -12,7 +12,8 @@ var objectAssign = require( 'object-assign' );
  */
 function getAllStar( person ) {
   // override properties from all-stars if available
-  return objectAssign( person, allStars( person ) );
+  var allStar = allStars( person );
+  return allStar ? objectAssign( person, allStar.subset() ) : person;
 }
 
 /**

--- a/util/package.spec.js
+++ b/util/package.spec.js
@@ -1,4 +1,5 @@
 import test from 'ava';
+import { authors, index } from 'all-stars';
 import packageUtil from './package';
 
 test( 'getAuthor - author is a string', t => {
@@ -74,6 +75,43 @@ test( 'getAuthor - author is not defined', t => {
   let author = packageUtil.getAuthor( packageJson );
 
   t.same( author, false );
+  t.end();
+} );
+
+test( 'getAuthor - author in all-stars has additional properties', t => {
+  let packageJson = {
+    author : {
+      name  : 'Archimedes of Syracuse',
+      email : 'archimedes@syracuse.io',
+      url   : 'https://en.wikipedia.org/wiki/Archimedes'
+    }
+  };
+
+  // add our fake author to all-stars for mocking purposes
+  let allStarAuthors = authors();
+  let allStarIndex = index();
+
+  let fakeAuthorId = 'PiDude314159265359';
+
+  allStarAuthors[ fakeAuthorId ] = {
+    npmUsers    : [ fakeAuthorId ],
+    names       : [ packageJson.author.name ],
+    emails      : [ packageJson.author.email ],
+    githubUsers : [ fakeAuthorId ],
+    twitters    : [ fakeAuthorId ]
+  };
+
+  allStarIndex[ packageJson.author.name ] = fakeAuthorId;
+  allStarIndex[ packageJson.author.email ] = fakeAuthorId;
+
+  // test
+  let author = packageUtil.getAuthor( packageJson );
+
+  t.is( author.name, packageJson.author.name );
+  t.is( author.email, packageJson.author.email );
+  t.is( author.npm, fakeAuthorId );
+  t.is( author.github, fakeAuthorId );
+  t.is( author.twitter, fakeAuthorId );
   t.end();
 } );
 

--- a/util/package.spec.js
+++ b/util/package.spec.js
@@ -88,12 +88,9 @@ test( 'getAuthor - author in all-stars has additional properties', t => {
   };
 
   // add our fake author to all-stars for mocking purposes
-  let allStarAuthors = authors();
-  let allStarIndex = index();
-
   let fakeAuthorId = 'PiDude314159265359';
 
-  allStarAuthors[ fakeAuthorId ] = {
+  authors[ fakeAuthorId ] = {
     npmUsers    : [ fakeAuthorId ],
     names       : [ packageJson.author.name ],
     emails      : [ packageJson.author.email ],
@@ -101,16 +98,16 @@ test( 'getAuthor - author in all-stars has additional properties', t => {
     twitters    : [ fakeAuthorId ]
   };
 
-  allStarIndex[ packageJson.author.name ] = fakeAuthorId;
-  allStarIndex[ packageJson.author.email ] = fakeAuthorId;
+  index[ packageJson.author.name ] = fakeAuthorId;
+  index[ packageJson.author.email ] = fakeAuthorId;
 
   // test
   let author = packageUtil.getAuthor( packageJson );
 
   t.is( author.name, packageJson.author.name );
   t.is( author.email, packageJson.author.email );
-  t.is( author.npm, fakeAuthorId );
-  t.is( author.github, fakeAuthorId );
+  t.is( author.npmUser, fakeAuthorId );
+  t.is( author.githubUser, fakeAuthorId );
   t.is( author.twitter, fakeAuthorId );
   t.end();
 } );

--- a/util/package.spec.js
+++ b/util/package.spec.js
@@ -106,8 +106,8 @@ test( 'getAuthor - author in all-stars has additional properties', t => {
 
   t.is( author.name, packageJson.author.name );
   t.is( author.email, packageJson.author.email );
-  t.is( author.npmUser, fakeAuthorId );
-  t.is( author.githubUser, fakeAuthorId );
+  t.is( author.npm, fakeAuthorId );
+  t.is( author.github, fakeAuthorId );
   t.is( author.twitter, fakeAuthorId );
   t.end();
 } );


### PR DESCRIPTION
:stars: Initial stab to implement issue #6.

Basically adds a private `getAllStar()` function to `util/package.js` that all returned objects from `getAuthor()` and `getMaintainers()` are filtered through. The new method checks if the person is known to `all-stars` and merges its data with the current person object. This adds [all properties and functions from the `allStars.AllStar` object](https://github.com/nexdrew/all-stars#allstarsallstar) (e.g. `githubUser`, `npmUser`, `twitter`, etc), which may have `null` or `undefined` values.

Added a single test to `util/package.spec.js` to cover the "found in all-stars" scenario. It uses mocked author data so that it's not dependent on actual data in all-stars, but unfortunately the mocking requires knowledge of how the data within all-stars is organized. If you think this is a problem, I'll probably need to add a mocking library (as a dev dependency) to mock out the all-stars methods instead.

This gets the job done, but suggestions for improvement are welcomed!
