### PR TITLE
eslint-plugin-node

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,8 @@
           "modules": true
       }
   },
+  "plugins": ["node"],
+  "extends": ["eslint:recommended", "plugin:node/recommended"],
   "rules": {
     "indent": [
       2,

--- a/lib/analyzers.js
+++ b/lib/analyzers.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var fs      = require( 'fs' );
 var path    = require( 'path' );
 var globby  = require( 'globby' );
 
@@ -12,7 +11,6 @@ var globby  = require( 'globby' );
  * @return {Array}         list of reporter methods
  */
 function getAnalyzers( config ) {
-  var analyzers;
   var methods  = {};
   var basePath = config.filePaths.analyzers;
 

--- a/lib/analyzers/bower/index.js
+++ b/lib/analyzers/bower/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var fs          = require( 'fs' );
 var path        = require( 'path' );
 var globby      = require( 'globby' );
 

--- a/lib/analyzers/jspm/index.js
+++ b/lib/analyzers/jspm/index.js
@@ -1,11 +1,8 @@
 'use strict';
 
-var fs          = require( 'fs' );
 var path        = require( 'path' );
 var globby      = require( 'globby' );
 
-var creditUtil  = require( '../../credit' );
-var packageUtil = require( '../../package' );
 var getNpmCredits = require( '../npm' ).getNpmCredits;
 var getBowerCredits = require( '../bower' ).getBowerCredits;
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "index.js",
     "lib"
   ],
+  "engines": {
+    "node": ">=4"
+  },
   "scripts": {
     "add": "all-contributors add",
     "lint": "eslint lib/*.js lib/**/*.js",
@@ -30,6 +33,7 @@
     "ava": "^0.16.0",
     "coveralls": "^2.11.4",
     "eslint": "^3.7.1",
+    "eslint-plugin-node": "^2.1.3",
     "fs-extra": "^0.30.0",
     "nyc": "^8.3.1",
     "tmp": "0.0.29"


### PR DESCRIPTION
This PR adds eslint-plugin-node and limits features to those supported in node >=4.
